### PR TITLE
Bugfix/ci break

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d build -m \"[skip ci] Updates\""
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/containers/Spotlight/reducer.js
+++ b/src/containers/Spotlight/reducer.js
@@ -21,7 +21,7 @@ function spotLightReducer(state = initialState, action) {
     case SET_SPOT_DONE: {
       const {
         error,
-        data, // get data from fetch epics
+        // data, // get data from fetch epics
       } = action.payload;
       if (error) {
         return state.update('setSpotMeta', updateMetaError);


### PR DESCRIPTION
lint error 導致 ci failed

```
Failed to compile.

./src/containers/Spotlight/reducer.js
  Line 24:  'data' is assigned a value but never used  no-unused-vars
```
https://circleci.com/gh/flying-blue-magpie/Spotlight_Frontend/46

修正 lint error，並把 gh-pages branch CI 移除（沒有必要跑），怕 circleci 的免費額度用完 💩 